### PR TITLE
 Allow low-dimensional mediator selection in HIMA 

### DIFF
--- a/R/hima.R
+++ b/R/hima.R
@@ -94,6 +94,8 @@ hima <- function(X, Y, M, COV.XM = NULL, COV.MY = COV.XM,
     } else {
       d <- topN  # the number of top mediators that associated with exposure (X)
     }
+  
+    d <- max(p, d) # if d > p select all mediators
     
     #########################################################################
     ################################ STEP 1 #################################

--- a/R/hima.R
+++ b/R/hima.R
@@ -95,7 +95,7 @@ hima <- function(X, Y, M, COV.XM = NULL, COV.MY = COV.XM,
       d <- topN  # the number of top mediators that associated with exposure (X)
     }
   
-    d <- max(p, d) # if d > p select all mediators
+    d <- min(p, d) # if d > p select all mediators
     
     #########################################################################
     ################################ STEP 1 #################################


### PR DESCRIPTION
I wanted to try out HIMA on a low-dimensional mediator set but it errored with the following message: 
```
Step 1: Sure Independent Screening ...     (2018-03-01 12:07:04)
Step 2: Penalized estimate (MCP) ...     (2018-03-01 12:07:04)
Error in x[, ii] : subscript out of bounds
```

I figured out that the fix was simple: set a `topN`. However, if `d > p` we can always assume that `d` should be `p`, essentially skipping the selection part of SIS.