### PR TITLE
Fix: incorrect ID in return list in hima_survival.R

### DIFF
--- a/R/hima_survival.R
+++ b/R/hima_survival.R
@@ -188,7 +188,7 @@ hima_survival <- function(X, M, OT, status, COV = NULL,
 
   if (length(ID_fdr) > 0) {
     out_result <- data.frame(
-      Index = M_ID_name[ID_fdr],
+      Index = M_ID_name[ID_SIS][ID_fdr],
       alpha_hat = alpha_SIS_est[ID_fdr],
       alpha_se = alpha_SIS_SE[ID_fdr],
       beta_hat = beta_DLASSO_SIS_est[ID_fdr],


### PR DESCRIPTION
Hello! I was recently using HIMA for my data analysis, and I really appreciate the package — it's a great tool for mediation analysis.

While going through the results, I noticed a small issue in the returned output: the ID field in the returned list uses the original full ID set M_ID_name instead of the SIS selected subset, which may affect the returned results.

This PR fixes that by replacing Index = M_ID_name[ID_fdr] with Index = M_ID_name[ID_SIS][ID_fdr].