### PR TITLE
Fix loops for single mediator and add test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Collate:
     onAttach.R
     HIMA-package.R
 VignetteBuilder: knitr
-Suggests: knitr, rmarkdown
+Suggests: knitr, rmarkdown, testthat
 Encoding: UTF-8
 LazyData: true
 URL: https://github.com/YinanZheng/HIMA/

--- a/R/hima_survival.R
+++ b/R/hima_survival.R
@@ -145,6 +145,7 @@ hima_survival <- function(X, M, OT, status, COV = NULL,
     V1_P <- abs(beta_LDPE_est) / beta_LDPE_SE
     c(beta_LDPE_est, beta_LDPE_SE, 2 * (1 - pnorm(V1_P, 0, 1)))
   }
+  if (is.null(dim(beta_results))) beta_results <- matrix(beta_results, nrow = 1)
   beta_DLASSO_SIS_est <- beta_results[, 1]
   beta_DLASSO_SIS_SE <- beta_results[, 2]
   P_beta_SIS <- beta_results[, 3]
@@ -158,6 +159,7 @@ hima_survival <- function(X, M, OT, status, COV = NULL,
     sd_1 <- abs(est_a) / se_a
     c(est_a, se_a, 2 * (1 - pnorm(sd_1, 0, 1)))
   }
+  if (is.null(dim(alpha_results))) alpha_results <- matrix(alpha_results, nrow = 1)
   alpha_SIS_est <- alpha_results[, 1]
   alpha_SIS_SE <- alpha_results[, 2]
   P_alpha_SIS <- alpha_results[, 3]

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(HIMA)
+
+test_check("HIMA")

--- a/tests/testthat/test-hima-survival-d1.R
+++ b/tests/testthat/test-hima-survival-d1.R
@@ -1,0 +1,19 @@
+test_that("hima_survival runs when d is 1", {
+  data(SurvivalData)
+  pheno <- SurvivalData$PhenoData
+  mediator <- SurvivalData$Mediator
+  expect_silent(
+    hima_survival(
+      X = pheno$Treatment,
+      OT = pheno$Time,
+      status = pheno$Status,
+      M = mediator,
+      COV = pheno[, c("Sex", "Age")],
+      topN = 1,
+      scale = FALSE,
+      FDRcut = 1,
+      verbose = FALSE,
+      parallel = FALSE
+    )
+  )
+})


### PR DESCRIPTION
## Summary
- handle single mediator case in `hima_survival`
- add `testthat` to Suggests
- add unit test ensuring `hima_survival` works when `d` is 1

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: R not installed)*
- `R CMD check . --no-manual` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68475a2a8ff08328920e15bc6128ad63