### PR TITLE
Fix dimension handling in hima_survival

### DIFF
--- a/R/hima_survival.R
+++ b/R/hima_survival.R
@@ -167,7 +167,7 @@ hima_survival <- function(X, M, OT, status, COV = NULL,
   #########################################################################
   if (verbose) message("Step 3: Multiple-testing procedure ...", "     (", format(Sys.time(), "%X"), ")")
 
-  PA <- cbind(t(P_alpha_SIS), t(P_beta_SIS))
+  PA <- cbind(P_alpha_SIS, P_beta_SIS)
   P_value <- apply(PA, 1, max) # the joint p-values for SIS variable
 
   ## the multiple-testing  procedure


### PR DESCRIPTION
## Summary
- fix `PA` so it forms a `d x 2` matrix instead of a `1 x 2d` matrix

## Testing
- `apt-get update` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68475a2605408328b95b3b32f8973920