### PR TITLE
Enable parallel execution in lasso-based HIMA paths

### DIFF
--- a/R/hima_classic.R
+++ b/R/hima_classic.R
@@ -222,7 +222,7 @@ hima_classic <- function(X, M, Y, COV.XM = NULL, COV.MY = COV.XM,
       if (verbose) message("    Estimating alpha (effect of X on M): ", appendLF = FALSE)
       alpha <- himasis(NA, M[, ID_test, drop = FALSE], X, COV.XM,
         glm.family = M.type,
-        modelstatement = "Mone ~ X", parallel = FALSE, ncore = ncore,
+        modelstatement = "Mone ~ X", parallel = parallel, ncore = ncore,
         verbose, tag = paste0("site-by-site alpha estimation (M ~ X + COV.XM, family: ", M.type, ")")
       )
     } else {

--- a/R/hima_dblasso.R
+++ b/R/hima_dblasso.R
@@ -153,7 +153,13 @@ hima_dblasso <- function(X, M, Y, COV = NULL,
   beta_DLASSO_SIS_SE <- matrix(0, 1, d)
   MZX_SIS <- MZX[, c(ID_SIS, (p + 1):(p + q + 1))]
 
-  DLASSO_fit <- suppressMessages(hdi::lasso.proj(x = MZX_SIS, y = Y, family = "gaussian"))
+  DLASSO_fit <- suppressMessages(hdi::lasso.proj(
+    x = MZX_SIS,
+    y = Y,
+    family = "gaussian",
+    parallel = parallel,
+    ncores = ncore
+  ))
   beta_DLASSO_SIS_est <- DLASSO_fit$bhat[1:d]
   beta_DLASSO_SIS_SE <- DLASSO_fit$se
   P_beta_SIS  <- as.numeric(DLASSO_fit$pval[1:d])


### PR DESCRIPTION
## Summary

This PR fixes two places where HIMA exposes `parallel`/`ncore` options but does not fully propagate them to lasso-related computation.

Changes are intentionally minimal:

- Pass `parallel` and `ncore` through to `hdi::lasso.proj()` inside `hima_dblasso()`.
- Preserve the user-provided `parallel` flag during the second `himasis()` call in the continuous `hima_classic()` path, including `penalty = "lasso"`.

## Motivation

While running HIMA as a baseline, we noticed that enabling `parallel = TRUE` did not parallelize the main de-biased lasso call in `hima_dblasso()`. The underlying `hdi::lasso.proj()` function already supports `parallel` and `ncores`, so this PR simply forwards HIMA's existing arguments.

Similarly, one alpha-estimation call in `hima_classic()` hard-coded `parallel = FALSE`, which prevents the existing parallel option from being honored in that step.

## Scope

This PR does not change default behavior. When `parallel = FALSE`, execution remains sequential as before.

## Testing

- Ran `git diff --check`.
- Parsed the touched R source files successfully with Rscript.